### PR TITLE
Update Ruby stream from 2.5 -> 2.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi8/ubi:8.2-343
 
-RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.5 && \
+RUN dnf -y --disableplugin=subscription-manager module enable ruby:2.6 && \
     dnf -y --disableplugin=subscription-manager --setopt=tsflags=nodocs install \
       ruby-devel \
       # To compile native gem extensions


### PR DESCRIPTION
Just bumping the ruby module version from 2.5 -> 2.6, been meaning to do this for a while but a bug in the ruby2_keywords gem is leading to this rather than pinning them gem. We have been testing against 2.6 in travis for months now so it should be pretty safe. (I'm opening this on all repos, if we don't want to do this I am completely fine with closing this for now.)